### PR TITLE
Remember results across nixpkgs versions

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -20,8 +20,8 @@ fn log_command_output(output: Output) {
     }
 }
 
-pub fn load_r13y_log(rev: &str) -> Vec<BuildResponseV1> {
-    if let Ok(log_file) = File::open(format!("reproducibility-log-{}.json", rev)) {
+pub fn load_r13y_log() -> Vec<BuildResponseV1> {
+    if let Ok(log_file) = File::open("reproducibility-log.json") {
         serde_json::from_reader(log_file).expect("Unable to parse r13y log")
     } else {
         Vec::new()
@@ -29,9 +29,9 @@ pub fn load_r13y_log(rev: &str) -> Vec<BuildResponseV1> {
 }
 
 pub struct JobInstantiation {
-    pub results: Vec<BuildResponseV1>,
     pub to_build: HashSet<PathBuf>,
-    pub skip_list: HashSet<PathBuf>
+    pub to_report: HashSet<PathBuf>,
+    pub results: Vec<BuildResponseV1>,
 }
 
 pub fn eval(instruction: BuildRequest) -> JobInstantiation {
@@ -41,22 +41,9 @@ pub fn eval(instruction: BuildRequest) -> JobInstantiation {
 
     let mut results = Vec::new();
 
-    let mut skip_list = HashSet::new();
-    let prev_results = load_r13y_log(&job.nixpkgs_revision);
-    for elem in prev_results.into_iter() {
-        if elem.status == BuildStatus::FirstFailed {
-            info!(
-                "Ignoring for skiplist as it failed the first time: {:#?}",
-                &elem
-            );
-        } else {
-            skip_list.insert(PathBuf::from(&elem.drv));
-            results.push(elem);
-        }
-    }
-
     let tmpdir = PathBuf::from("./tmp/");
 
+    let mut to_report: HashSet<PathBuf> = HashSet::new();
     let mut to_build: HashSet<PathBuf> = HashSet::new();
 
     for (subset, attrs) in job.subsets.into_iter() {
@@ -102,8 +89,26 @@ pub fn eval(instruction: BuildRequest) -> JobInstantiation {
                 to_build.insert(line.into());
             }
         }
+        for line in query_requisites.stdout.lines().filter_map(Result::ok) {
+            if line.ends_with(".drv") {
+                to_report.insert(line.into());
+            }
+        }
         log_command_output(query_requisites);
     }
 
-    JobInstantiation { to_build, results, skip_list }
+    let prev_results = load_r13y_log();
+    for elem in prev_results.into_iter() {
+        if elem.status == BuildStatus::FirstFailed {
+            info!(
+                "Ignoring for skiplist as it failed the first time: {:#?}",
+                &elem
+            );
+        } else {
+            to_build.remove(&PathBuf::from(&elem.drv));
+            results.push(elem);
+        }
+    }
+
+    JobInstantiation { to_build, to_report, results }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -20,7 +20,7 @@ pub fn report(instruction: BuildRequest) {
     };
 
     let JobInstantiation {
-        to_build, results, ..
+        to_report, results, ..
     } = eval(instruction.clone());
 
     let tmpdir = PathBuf::from("./tmp/");
@@ -40,9 +40,7 @@ pub fn report(instruction: BuildRequest) {
     let mut first_failed: Vec<String> = vec![];
 
     for response in results.into_iter().filter(|response| {
-        (match response.request {
-            BuildRequest::V1(ref req) => req.nixpkgs_revision == job.nixpkgs_revision,
-        }) && to_build.contains(&PathBuf::from(&response.drv))
+        to_report.contains(&PathBuf::from(&response.drv))
     }) {
         total += 1;
         match response.status {


### PR DESCRIPTION
The downside of this is that it might miss some problems where a build
is sometimes reproducible but not always. To catch those (e.g. on CI)
you'd want to remove any previous `reproducibility-log.json` before
running another build.

The advantage of this is that it becomes much faster to generate
reports for different nixpkgs versions that are fairly close
together (since many derivations are actually identical and don't
have to be re-checked).

A smaller advantage is that (by manually renaming and fixing
reproducibility-log.json.part) you can now resume an aborted
report.