### PR TITLE
Fixup cloudfront report expiration

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -7,4 +7,5 @@ UPLOAD_DEST=$2
 buildkite-agent artifact download "$REPORT_NAME.tar.xz" ./
 tar -xf "./$REPORT_NAME".tar.xz
 
-aws s3 cp "$REPORT_NAME" "s3://r13y-com$UPLOAD_DEST" --recursive --acl public-read
+aws s3 cp "$REPORT_NAME" "s3://r13y-com$UPLOAD_DEST" --recursive --acl public-read \
+    --cache-control "public; max-age=3600"


### PR DESCRIPTION
Cloudfront would currently cache all files for up to 24h (as per default behavior documented here https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
This tries to mitigate this, by lowering the cache expiration down to 1h.