### PR TITLE
Include attr name into template

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -39,6 +39,8 @@ pub fn report(instruction: BuildRequest) {
     let mut unchecked = 0;
     let mut first_failed: Vec<String> = vec![];
 
+    let attr_name = job.subsets.values().next().unwrap().as_ref().unwrap().get(0).unwrap().join(".");
+
     for response in results.into_iter().filter(|response| {
         (match response.request {
             BuildRequest::V1(ref req) => req.nixpkgs_revision == job.nixpkgs_revision,
@@ -113,7 +115,8 @@ pub fn report(instruction: BuildRequest) {
             percent = format!("{:.*}%", 2, 100.0 * (reproducible as f64 / total as f64)),
             revision = job.nixpkgs_revision,
             now = Utc::now().to_string(),
-            unreproduced_list = unreproducible_list.join("\n")
+            unreproduced_list = unreproducible_list.join("\n"),
+            attr_name = attr_name,
         )
         .as_bytes(),
     )

--- a/src/report/template.html
+++ b/src/report/template.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <title>Is NixOS Reproducible?</title>
-<meta name="description" content="nixos-unstable's iso_minimal.x86_64-linux build is {percent} reproducible!" />
+<meta name="description" content="nixos-unstable's {attr_name} build is {percent} reproducible!" />
 
 <!-- Twitter Card data -->
 <meta name="twitter:card" value="summary">
@@ -11,7 +11,7 @@
 <meta property="og:type" content="article" />
 <meta property="og:url" content="https://r13y.com/" />
 <meta property="og:image" content="https://nixos.org/logo/nixos-logo-only-hires.png" />
-<meta property="og:description" content="nixos-unstable's iso_minimal.x86_64-linux build is {percent} reproducible!" />
+<meta property="og:description" content="nixos-unstable's {attr_name} build is {percent} reproducible!" />
 <style>
 body {{
     max-width: 50em;
@@ -58,16 +58,16 @@ body {{
 </h1>
 <h1>Is NixOS Reproducible?</h1>
 <h2>Tracking: <code>nixos-unstable</code>'s
-    <code>iso_minimal</code> job for <code>x86_64-linux</code>.</h2>
+    <code>{attr_name}</code> job for <code>x86_64-linux</code>.</h2>
 <p>Build via:</p>
 <pre>
 git clone https://github.com/nixos/nixpkgs.git
 cd nixpkgs
 git checkout {revision}
-nix-build ./nixos/release-combined.nix -A nixos.iso_minimal.x86_64-linux
+nix-build ./nixos/release-combined.nix -A nixos.{attr_name}
 </pre>
 
-<h1 style="color: green">{reproduced} out of {total} ({percent}) paths in the minimal installation image are reproducible!</h1>
+<h1 style="color: green">{reproduced} out of {total} ({percent}) paths in the {attr_name} installation image are reproducible!</h1>
 <p>{unchecked} unchecked</p>
 <hr>
 <h3>unreproduced paths</h3>


### PR DESCRIPTION
Making the template a bit more dynamic to allow publishing multiple attribute sets for installers.

Probably would have an alternate template for non-installers and other sets.